### PR TITLE
adding check for plugin directory

### DIFF
--- a/src/Services/PluginLoader.cs
+++ b/src/Services/PluginLoader.cs
@@ -67,6 +67,11 @@ public partial class Core {
             private void ScanAndLoadPlugins() {
                 ILoggerFactory loggerFactory;
 
+                if (!Directory.Exists(_appConfig.PLUGIN_DIRECTORY)) {
+                    // If the plugin directory doesn't exist, we can't load plugins.  Quietly return and try again later
+                    return;
+                }
+
                 foreach (string file in System.IO.Directory.GetFiles(_appConfig.PLUGIN_DIRECTORY, "*.json.spacefx_plugin")) {
                     string plugin_json = System.IO.File.ReadAllText(file);
                     Models.PLUG_IN? config_plugin;


### PR DESCRIPTION
Not all apps have plugin directories (i.e. Payload apps) - this allows the service to quietly recheck later for plugins, but not log an error every time the scan occurs.